### PR TITLE
Remove wrong make command

### DIFF
--- a/ssa/Makefile
+++ b/ssa/Makefile
@@ -1,7 +1,5 @@
 all :
 	bapbuild -package cmdliner ssa.plugin
-	bapbuild -package cmdliner deadcode.plugin
-
 
 clean:
 	bapbuild -clean


### PR DESCRIPTION
Why do we build deadcode plugin here?