### PR TITLE
updating predicate system in saluki

### DIFF
--- a/saluki/predicate.ml
+++ b/saluki/predicate.ml
@@ -3,7 +3,7 @@ open Bap.Std
 
 
 type t = {
-  sat : 'a. 'a term -> var -> bool
+  sat : 'a. 'a term -> exp -> bool
 }
 
 exception Unbound_predicate of string [@@deriving sexp]

--- a/saluki/predicate.mli
+++ b/saluki/predicate.mli
@@ -1,7 +1,7 @@
 open Bap.Std
 
-type t = {sat : 'a. 'a term -> var -> bool}
+type t = {sat : 'a. 'a term -> exp -> bool}
 
 val register : string -> t -> unit
 val lookup : string -> t option
-val test : string -> 'a term -> var -> bool
+val test : string -> 'a term -> exp -> bool

--- a/saluki/saluki.ml
+++ b/saluki/saluki.ml
@@ -2,6 +2,7 @@ open Core_kernel.Std
 open Bap.Std
 open Format
 open Spec
+include Self()
 
 let taint spec proj =
   let prog = Project.program proj in
@@ -26,4 +27,6 @@ let solve spec proj =
 let () =
   let spec = Specification.spec in
   Project.register_pass ~deps:["callsites"] ~name:"taint"  (taint spec);
-  Project.register_pass' ~name:"solve" (solve spec)
+  Project.register_pass' ~name:"solve" (solve spec);
+  Project.register_pass' ignore
+    ~deps:[name^"-taint"; "propagate-taint"; name^"-solve"]

--- a/saluki/specification.ml
+++ b/saluki/specification.ml
@@ -71,12 +71,22 @@ let magic_leaks_into_malloc =
   ] vars [reg p; reg q; reg v] such
     that [forall v such that is_black; q/p]
 
+let recv_to x x_args =
+  define ("recv_to_"^x) [
+    rule "if_data_dep"
+      [sub "recv" [_';p;_';_']]
+      [sub x x_args]
+  ] vars [reg *p; reg *q] such that [q/p]
+
+
 let spec = specification [
     (* unescaped_sql append_n; *)
     (* unescaped_sql append_s; *)
     maybe_checked "malloc";
     (* maybe_checked "calloc"; *)
     untrusted_input "strcpy" "system";
+    untrusted_input "sprintf" "system";
+    recv_to "strcpy"  [_';q];
     (* data_sanitized "fgets" "realpath" "fopen"; *)
     (* magic "read" is_black; *)
     (* magic "readv" is_black; *)

--- a/saluki/state.ml
+++ b/saluki/state.ml
@@ -105,7 +105,7 @@ let sat ts term hyp kind v bil : hyp option =
       hyp >>= fun hyp ->
       let sat c = Option.some_if c hyp in
       match cs with
-      | Fun (id,v') -> V.(v = v') ==> Predicate.test id term bil |> sat
+      | Fun (id,v') -> V.(v = v') ==> Predicate.test id term (Bil.var bil) |> sat
       | Var (v',ex) -> V.(v' = v) ==> Var.(ex = bil) |> sat
       | Dep (v1,v2) ->  match kind with
         | `def when V.(v2 = v) -> dep_def bil v2

--- a/saluki/utilities.ml
+++ b/saluki/utilities.ml
@@ -3,7 +3,8 @@ open Bap.Std
 
 let label_matches l id = match l with
   | Indirect _ -> false
-  | Direct tid -> Tid.name tid = "@"^id
+  | Direct tid ->
+    id = "_" || Tid.name tid = "@"^id
 
 let callee call prog = match Call.target call with
   | Indirect _ -> None


### PR DESCRIPTION
* added support for wildcards in function name. This is a first
  step, before we will make possible to specify variables instead
  of function names, and to predicate over this variable.

* predicates are now called on expression. This fixes
  a long term issue, that we were unable to seed constant terms.
  Also, this is a move into merging saluki predicate system into
  with the `bap-bml` system.

* added new pass `--saluki` that is equivalent to
  `--saluki-seed --propagate-taint --saluki-solve`