### PR TITLE
Saluki pattern never

### DIFF
--- a/saluki/solution.mli
+++ b/saluki/solution.mli
@@ -5,7 +5,7 @@ open Format
 
 type t [@@deriving bin_io, compare, sexp]
 
-type hypothesis = tid Pat.Map.t
+type hypothesis = tid Pat.Map.t [@@deriving bin_io, compare, sexp]
 
 
 val create : spec -> (defn * hypothesis) seq -> t

--- a/saluki/solver.ml
+++ b/saluki/solver.ml
@@ -45,7 +45,10 @@ let search_sub vis sub =
       foreach jmp_t blk ~f:vis#jmp)
 
 let search (vis : 'a vis) prog =
+  foreach sub_t prog ~f:(search_sub vis) >>= fun () ->
+  SM.update State.start_conclusions >>= fun () ->
   foreach sub_t prog ~f:(search_sub vis)
+
 
 let do_nothing _ = ()
 

--- a/saluki/spec.mli
+++ b/saluki/spec.mli
@@ -110,6 +110,7 @@ module Language : sig
   val (:=) : V.t -> rhs -> pat
   val use : V.t -> rhs
   val any : V.t -> pat
+  val never : pat
 
   (** {3 Calls}  *)
   val call : id -> V.t list -> rhs

--- a/saluki/spec_types.ml
+++ b/saluki/spec_types.ml
@@ -2,7 +2,7 @@ open Core_kernel.Std
 open Bap.Std
 
 type id = string
-[@@deriving bin_io, compare, sexp]
+  [@@deriving bin_io, compare, sexp]
 
 type v = V.t [@@deriving bin_io, compare, sexp]
 
@@ -11,32 +11,33 @@ module Constr = struct
     | Dep of v * v
     | Var of v * var
     | Fun of id * v
-  [@@deriving bin_io, compare, sexp, variants]
+    [@@deriving bin_io, compare, sexp, variants]
 end
 
 type constr = Constr.t
-[@@deriving bin_io, compare, sexp]
+  [@@deriving bin_io, compare, sexp]
 
 module S = struct
   type t =
     | Reg
     | Ptr
-  [@@deriving bin_io, compare, sexp, variants]
+    [@@deriving bin_io, compare, sexp, variants]
 end
 
 type s = S.t
-[@@deriving bin_io, compare, sexp]
+  [@@deriving bin_io, compare, sexp]
 
 module Pat = struct
   type t =
+    | Never
     | Call of id * v * v list
     | Jump of [`call | `goto | `ret | `exn | `jmp] * v * v
     | Move of v * v
     | Load of v * v
     | Wild of v
     | Store of v * v
-  [@@deriving bin_io, compare, sexp, variants]
+    [@@deriving bin_io, compare, sexp, variants]
 end
 
 type pat = Pat.t
-[@@deriving bin_io, compare, sexp]
+  [@@deriving bin_io, compare, sexp]

--- a/saluki/specification.ml
+++ b/saluki/specification.ml
@@ -13,7 +13,7 @@ let maybe_checked name =
 let data_sanitized src san sink =
   define ("BYPASS/data_may_passthrough_"^san^"_before_"^sink) [
     rule ("if_data_passthrough_"^san)
-      [sub src[p]; sub sink[t]]
+      [sub src[p;_';_';_']; sub sink[t]]
       [sub san[s;r]]
   ] vars [reg *p; reg *t; reg *r; reg *s] such
     that [s/p; t/r; t/p]

--- a/saluki/specification.ml
+++ b/saluki/specification.ml
@@ -15,8 +15,8 @@ let data_sanitized src san sink =
     rule ("if_data_passthrough_"^san)
       [sub src[p]; sub sink[t]]
       [sub san[s;r]]
-  ] vars [reg *p; reg *q; reg *t; reg *r; reg *s] such
-    that [s/p; t/r]
+  ] vars [reg *p; reg *t; reg *r; reg *s] such
+    that [s/p; t/r; t/p]
 
 let untrusted_input src sink =
   define ("TAINT/"^src^"_may_leak_into_"^sink) [

--- a/saluki/state.ml
+++ b/saluki/state.ml
@@ -6,6 +6,10 @@ open Utilities
 
 open Option.Monad_infix
 
+module Dep = Comparable.Make(struct
+    type t = v * v [@@deriving bin_io, compare, sexp]
+  end)
+
 (** a lattice for dependency equality class.*)
 type eq =
   | Top              (* superset *)
@@ -18,7 +22,7 @@ type hyp = {
   defn    : Defn.t;          (** definition from which we born   *)
   patts   : Pat.Set.t;       (** patterns to be matched          *)
   proofs  : tid Pat.Map.t;   (** map from a patter to matched t  *)
-  ivars   : eq V.Map.t;      (** equivalence classes for inputs  *)
+  deps    : eq Dep.Map.t;    (** equivalence classes for inputs  *)
   constrs : constr list;     (** constraints that we mus satisfy *)
   pending : Pat.Set.t;
 } [@@deriving fields]
@@ -38,21 +42,20 @@ type solution = Solution.t
 
 type matcher = Match.matcher
 
-
-
 let hyp_of_defn defn : hyp =
   let constrs = Defn.constrs defn in
   let proofs = Pat.Map.empty in
-  let ivars =
-    Set.fold (Defn.ivars defn) ~init:V.Map.empty ~f:(fun ivars v ->
-        Map.add ivars ~key:v ~data:Top) in
+  let deps =
+    List.fold constrs ~init:Dep.Map.empty ~f:(fun deps -> function
+        | Constr.Dep (v',v) -> Map.add deps ~key:(v',v) ~data:Top
+        | _ -> deps) in
   let (++) pats r = Set.union pats (Pat.Set.of_list r) in
   let patts,pending =
     List.fold (Defn.rules defn)
       ~init:(Pat.Set.empty,Pat.Set.empty) ~f:(fun (pats,pending) r ->
           pats ++ Rule.premises r,
           pending ++ Rule.conclusions r) in
-  {defn; patts; ivars; proofs; constrs; pending}
+  {defn; patts; deps; proofs; constrs; pending}
 
 let create s t = {
   init = Spec.defns s |> List.map ~f:hyp_of_defn;
@@ -82,63 +85,65 @@ let debug id term fmt =
   then eprintf fmt
   else ifprintf err_formatter fmt
 
-let sat ts term hyp kind v bil : hyp option =
-  let dep_use y x =
+(* BUG: there should be union on taints for OR uses *)
+
+let sat ts term hypo kind v bil : hyp option =
+  let dep_use hyp y x =
     List.Assoc.find (Defn.vars hyp.defn) v >>|
     taint_of_sort >>= fun taints ->
     match taints ts (Term.tid term) y with
     | ss when Set.is_empty ss -> None
-    | ss -> match Map.find_exn hyp.ivars x with
+    | ss -> match Map.find_exn hyp.deps (v,x) with
       | Top -> Some {
           hyp with
-          ivars = Map.add hyp.ivars ~key:x ~data:(Set ss)
+          deps = Map.add hyp.deps ~key:(v,x) ~data:(Set ss)
         }
       | Set xs ->
-        (* this is an error! it is \/ instead of /\ *)
         let ss = Set.inter ss xs in
         if Set.is_empty ss then None
         else Some {
             hyp with
-            ivars = Map.add hyp.ivars ~key:x ~data:(Set ss)
+            deps = Map.add hyp.deps ~key:(v,x) ~data:(Set ss)
           } in
-  let dep_def bil x =
+  let dep_def hyp bil y =
     List.Assoc.find (Defn.vars hyp.defn) v >>|
     seed_of_sort >>= fun get_seed ->
     get_seed ts (Term.tid term) bil >>= fun seed ->
-    match Map.find_exn hyp.ivars x with
-    | Top -> Some {
+    match Map.find_exn hyp.deps (y,v) with
+    | Top ->
+      Some {
         hyp with
-        ivars = Map.add hyp.ivars ~key:x
+        deps = Map.add hyp.deps ~key:(y,v)
             ~data:(Set (Tid.Set.singleton seed))
       }
     | Set seeds ->
       if Set.mem seeds seed then (Some hyp) else None in
   let open Constr in
-  List.fold hyp.constrs ~init:(Some hyp) ~f:(fun hyp cs ->
+  List.fold hypo.constrs ~init:(Some hypo) ~f:(fun hyp cs ->
       hyp >>= fun hyp ->
       let sat c = Option.some_if c hyp in
       match cs with
       | Fun (id,v') -> V.(v = v') ==> Predicate.test id term (Bil.var bil) |> sat
       | Var (v',ex) -> V.(v' = v) ==> Var.(ex = bil) |> sat
-      | Dep (v1,v2) ->  match kind with
-        | `def when V.(v2 = v) -> dep_def bil v2
-        | `use when V.(v1 = v) -> dep_use bil v2
+      | Dep (v1,v2) -> match kind with
+        | `def when V.(v2 = v) -> dep_def hyp bil v1
+        | `use when V.(v1 = v) -> dep_use hyp bil v2
         | _ -> sat true)
 
 let merge_hyps xs =
   List.reduce_exn xs ~f:(fun h1 h2 -> {
         h1 with
-        ivars = Map.merge h1.ivars h2.ivars ~f:(fun ~key r ->
+        deps = Map.merge h1.deps h2.deps ~f:(fun ~key r ->
             Option.some @@ match r with
             | `Left _ | `Right _ -> assert false
             | `Both (Set xs, Set ys) -> Set (Set.union xs ys)
-            | `Both (_,Set xs)
-            | `Both  (Set xs,_) -> Set xs
+            | `Both (_,Set xs) | `Both  (Set xs,_) -> Set xs
             | `Both (Top,Top) -> Top)
       })
 
 let solution ts term hyp (eqs : Match.t) : hyp option =
-  let kind v = if Map.mem hyp.ivars v then `def else `use in
+  let kind v =
+    if Set.mem (Defn.ivars hyp.defn) v then `def else `use in
   let rec solve hyp = function
     | Match.All [] -> Some hyp
     | Match.Any [] -> None
@@ -147,8 +152,7 @@ let solution ts term hyp (eqs : Match.t) : hyp option =
     | Match.All constrs -> forall hyp constrs
     | Match.Any constrs -> exists hyp constrs
   and forall hyp constrs =
-    List.map constrs ~f:(solve hyp) |>
-    Option.all |> function
+    List.map constrs ~f:(solve hyp) |> Option.all |> function
     | None -> None
     | Some hyps -> Some (merge_hyps hyps)
   and exists hyp constrs =
@@ -157,17 +161,15 @@ let solution ts term hyp (eqs : Match.t) : hyp option =
     | hyps -> Some (merge_hyps hyps) in
   solve hyp eqs
 
-let proved hyp pat term = {
-  hyp with
-  proofs = Map.add hyp.proofs ~key:pat ~data:((Term.tid term));
-}
-
 let decide_hyp ts term hyp matches =
   Set.fold hyp.patts ~init:hyp ~f:(fun hyp pat ->
       if Map.mem hyp.proofs pat then hyp
       else match solution ts term hyp (matches pat) with
-        | Some hyp -> proved hyp pat term
-        | None -> {hyp with patts = Set.add hyp.patts pat})
+        | None -> hyp
+        | Some hyp -> {
+            hyp with
+            proofs = Map.add hyp.proofs ~key:pat ~data:(Term.tid term);
+          })
 
 let is_done h = Map.length h.proofs = Set.length h.patts
 

--- a/saluki/state.mli
+++ b/saluki/state.mli
@@ -5,6 +5,8 @@ type t
 
 val create : spec -> Tainter.t -> t
 
+val start_conclusions : t -> t
+
 (** [step state term matcher] given a function [matcher] that for each
     pattern returns a set of matching variables, performs one step of
     search of matching terms.*)

--- a/saluki/tainter.ml
+++ b/saluki/tainter.ml
@@ -122,10 +122,10 @@ let update_seed prog term taint map =
   | Some seed -> match Program.lookup def_t prog tid with
     | None -> map
     | Some def ->
-      let var = Def.lhs def in
-      Map.change map seed (function
-          | None -> Some (Var.Set.singleton var)
-          | Some vars -> Some (Set.add vars var))
+      let vars = Set.add (Def.free_vars def) (Def.lhs def) in
+      Map.update map seed ~f:(function
+          | None -> vars
+          | Some vars' -> Set.union vars vars)
 
 let reap prog =
   let update_seed t = update_seed prog t in

--- a/saluki/tests/test10.c
+++ b/saluki/tests/test10.c
@@ -1,5 +1,9 @@
 /* example of sanitization via call (CWE-22) */
 
+//! 00000...: fgets.p,_,_,_.
+//! 00000...: fopen.t.
+//! unproved: realpath.s,r.
+
 #include <limits.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/saluki/tests/test10.c
+++ b/saluki/tests/test10.c
@@ -14,7 +14,7 @@ int main(void) {
     if (!realpath(input,fixed)) {
         exit(1);
     } else {
-        FILE *f = fopen(fixed, "r");
+        FILE *f = fopen(input, "r");
         while (fgets(input,size,f))
             puts(input);
     }

--- a/saluki/tests/test15.c
+++ b/saluki/tests/test15.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+
+
+int init_connection(const char *name) {
+    struct addrinfo *addr;
+    int fd = -1;
+    if (getaddrinfo(name, "80",NULL,&addr) < 0) return -1;
+    if (addr == NULL) return -2;
+    fd = socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
+    if (fd < 0) return -3;
+    if (connect(fd, addr->ai_addr, addr->ai_addrlen) < 0) return -4;
+    freeaddrinfo(addr);
+    return fd;
+}
+
+
+int main(void) {
+    int fd;
+    char buf[BUFSIZ] = {0};
+    printf("Enter address: ");
+    if (fgets(buf,BUFSIZ - 1, stdin) == NULL) return 1;
+    fd = init_connection(buf);
+    if (fd < 0) return fd;
+    printf("Enter message: ");
+    if (fgets(buf, BUFSIZ - 1, stdin) == NULL) return 1;
+    if (send(fd, buf, BUFSIZ, 0) < 0) return 2;
+    close(fd);
+}

--- a/saluki/tests/test16.c
+++ b/saluki/tests/test16.c
@@ -1,0 +1,25 @@
+#include <stdlib.h>
+
+//!  00000...: p := malloc()
+//!  00000...: when c jmp _
+//!  Coverage: .* 100%
+
+
+int init(void *p) {
+    p = NULL;
+}
+
+int main(int argc, const char* argv[]) {
+    char *p;
+    init(p);
+    p = (char *) malloc(42);
+    if (argc > 0) {
+        if (!p) {
+            return 1;
+        }
+    } else {
+            return 2;
+    }
+
+    p[0] = '\0';
+}

--- a/saluki/tests/test17.c
+++ b/saluki/tests/test17.c
@@ -1,0 +1,24 @@
+#include <stdlib.h>
+
+//!  00000...: p := malloc()
+//!  00000...: when c jmp _
+//!  Coverage: .* 100%
+
+int init(void *p) {
+    p = NULL;
+}
+
+int main(int argc, const char* argv[]) {
+    char *p;
+    init(p);
+    p = (char *) malloc(42);
+    if (argc > 0) {
+        if (!p) {
+            return 1;
+        }
+    } else {
+            return 2;
+    }
+
+    p[0] = '\0';
+}

--- a/saluki/tests/test18.c
+++ b/saluki/tests/test18.c
@@ -1,0 +1,24 @@
+//!  00000...: p := malloc()
+//!  00000...: when c jmp _
+//!  Coverage: .* 100%
+
+#include <stdlib.h>
+
+int init(void *p) {
+    p = NULL;
+}
+
+int main(int argc, const char* argv[]) {
+    char *p;
+    init(p);
+    p = (char *) malloc(42);
+    if (argc > 0) {
+            exit(1);
+    } else {
+        if (!p) {
+            exit(2);
+        }
+    }
+
+    p[0] = '\0';
+}


### PR DESCRIPTION
This PR adds the `never` pattern and practically disables the notion of find. Now saluki will only look for the violations of a property. Although, all proves are still constructive, and they even be printed for the sake of testing is debugging, they no make much less sense. 

All properties, that were previously looked up with a find command should be rewritten in the following way: all patterns should be in the premises, and the conclusion will contain a `never` keyword, e.g., if you rule was `a,b |- c,d` then it should be `a,b,c,d |- never`

This PR also fixes quite a few bugs and limitations. The saluki will now run in two passes. At the first pass it verifies only premises, ignoring the conclusions. On the second pass, it will find proofs for all conclusions. (Or counter-examples, proving that they do not hold). 