### PR TITLE
A better commandline interface

### DIFF
--- a/saluki/Makefile
+++ b/saluki/Makefile
@@ -1,4 +1,4 @@
-OPTS = --symbolizer=ida ${options} --saluki
+OPTS = --symbolizer=ida ${options} --saluki --saluki-print-models
 case = *
 TEST = tests/test${case}.c
 
@@ -6,7 +6,7 @@ all : build install
 build : saluki
 
 saluki : *.ml
-		bapbuild -tag 'ppx(ppx-bap)' saluki.plugin
+		bapbuild -tag 'ppx(ppx-bap)' -package cmdliner saluki.plugin
 
 install: saluki
 		bapbundle install saluki.plugin

--- a/saluki/saluki.ml
+++ b/saluki/saluki.ml
@@ -8,7 +8,16 @@ let taint spec proj =
   let prog = Project.program proj in
   Project.with_program proj (Tainter.seed spec prog)
 
-let solve spec proj =
+let pp_models sol defn =
+  printf "@[models %s@." (Defn.name defn);
+  printf "%a" (Solution.pp_sat defn) sol
+
+let filter checks defs =
+  Spec.filter defs ~f:(fun defn -> 
+      List.exists checks ~f:(fun pattern -> 
+          String.substr_index (Defn.name defn) ~pattern <> None))
+
+let solve models spec proj =
   let prog = Project.program proj in
   let tainter = Tainter.reap prog in
   let state = State.create spec tainter in
@@ -16,18 +25,68 @@ let solve spec proj =
   let sol = State.solution state spec in
   printf "* Specification@.%a" Spec.pp spec;
   List.iter (Spec.defns spec) ~f:(fun defn ->
-      printf "@[* %s@." (Defn.name defn);
-      printf "@[** find %s@." (Defn.name defn);
-      printf "%a" (Solution.pp_sat defn) sol;
-      printf "@]";
-      printf "@[** assert %s@." (Defn.name defn);
+      printf "@[assert %s@." (Defn.name defn);
       printf "%a" (Solution.pp_unsat defn) sol;
-      printf "@]@]@.");
+      printf "@]";
+      if models then pp_models sol defn);
   Project.with_program proj (Solution.annotate sol prog)
 
-let () =
-  let spec = Specification.spec in
-  Project.register_pass ~deps:["callsites"] ~name:"taint"  (taint spec);
-  Project.register_pass ~name:"solve" (solve spec);
-  Project.register_pass' ignore
-    ~deps:[name^"-taint"; "propagate-taint"; name^"-solve"]
+let main models checks () = 
+  let spec = match checks with
+    | None -> Specification.spec 
+    | Some checks -> filter checks (Specification.spec) in
+  Option.is_some checks, spec,models
+
+
+module Cmdline = struct
+  open Cmdliner
+  let taint = 
+    let doc = "Run taint pass" in
+    Arg.(value & flag & info ["taint"] ~doc)
+  let solver = 
+    let doc = "Run saluki solver" in
+    Arg.(value & flag & info ["taint"] ~doc)
+  let saluki = 
+    let doc = "Taint, then propagate taint, then run the solver" in
+    Arg.(value & flag & info ["saluki"] ~doc)
+
+  let passes = 
+    Term.(const (fun _ _ _ -> ()) $taint $solver $saluki)
+
+  let check = 
+    let doc = "Check the specified list of properties. The list 
+    may contain a full property name, or just some substring. For 
+    example,if $(b,malloc) is specified, then all properties that
+    contain $(b,malloc) in their name will be checked." in
+    Arg.(value & opt (some (list string)) None &
+         info ["check"] ~doc)
+
+  let models = 
+    let doc =
+      "Output found models for each property. Usefull for testing 
+       and debugging." in
+    Arg.(value & flag & info ["print-models"] ~doc)
+
+  let man = [
+    `S "DESCRIPTION";
+    `P "Saluki is a proof base property verification engine. It uses 
+        a simple DSL that allows to specify program properties. The 
+        solver will verify that dataflow facts proves or disproves the 
+        given set of properties."
+  ]
+
+  let doc = "fast and stupid property checker"
+
+  let info = Term.info name ~doc ~man
+  let args = Term.(const main $models $check $passes),info
+end
+
+
+let () = match Cmdliner.Term.eval ~argv Cmdline.args with
+  | `Help | `Version -> exit 0
+  | `Error _ -> exit 1
+  | `Ok (autorun, spec,models) ->
+    Project.register_pass ~name:"solve" (solve models spec);
+    Project.register_pass ~deps:["callsites"] ~name:"taint"  (taint spec);
+    Project.register_pass' ignore ~autorun
+      ~deps:[name^"-taint"; "propagate-taint"; name^"-solve"]

--- a/saluki/spec.ml
+++ b/saluki/spec.ml
@@ -231,6 +231,8 @@ module Spec = struct
 
   let defns = ident
 
+  let filter = List.filter
+
   include Regular.Make(struct
       type nonrec t = t [@@deriving bin_io, compare, sexp]
       let version = "0.1"

--- a/saluki/spec.mli
+++ b/saluki/spec.mli
@@ -71,6 +71,7 @@ type defn = Defn.t [@@deriving bin_io, compare, sexp]
 module Spec : sig
   type t [@@deriving bin_io, compare, sexp]
   val defns : t -> defn list
+  val filter : t -> f:(defn -> bool) -> t
   include Regular with type t := t
 end
 


### PR DESCRIPTION
It is better, than nothing actually, as there wasn't any interface
before.

The interface now allows to specify concrete properties to be checked.
If not specified, then all known properties are checked. The properties
are specified as a substring, i.e., the specified name occurs as a
substring of a property, then it will be checked. For example,
```
bap --saluki-check=ERR
```
will check all properties in category ERR

```
bap --saluki-check=malloc
```
will check all properties, that containt `malloc` in their name.

To specify multiple properties, separate it with a comma, e.g.,
```
bap --saluki-check=ERR,TAINT,BYPASS
```

This PR also disables a printout of the models (aka finded proofs),
they can be enabled with `--saluki-print-models` option.