### PR TITLE
updates Saluki to BAP v1.4 and Core v0.9

### DIFF
--- a/saluki/Makefile
+++ b/saluki/Makefile
@@ -6,7 +6,7 @@ all : build install
 build : saluki
 
 saluki : *.ml
-		bapbuild -tag 'ppx(ppx-bap)' -package cmdliner saluki.plugin
+		bapbuild -package cmdliner saluki.plugin
 
 install: saluki
 		bapbundle install saluki.plugin

--- a/saluki/Makefile
+++ b/saluki/Makefile
@@ -1,4 +1,4 @@
-OPTS = --symbolizer=ida ${options} --saluki --saluki-print-models
+OPTS = ${options} --no-byteweight --saluki --saluki-print-models --propagate-taint-print-coverage
 case = *
 TEST = tests/test${case}.c
 

--- a/saluki/spec.ml
+++ b/saluki/spec.ml
@@ -6,7 +6,7 @@ open Format
 
 module Id = String
 type id = Id.t
-  [@@deriving bin_io, compare, sexp]
+[@@deriving bin_io, compare, sexp]
 
 let pp_list pp_sep pp_elem ppf xs =
   let rec pp ppf = function
@@ -154,7 +154,7 @@ module Defn = struct
         | _ -> ivars)
 
   let assert_all_defined cvars vars =
-    Set.find cvars ~f:(fun v -> not (List.Assoc.mem vars v)) |> function
+    Set.find cvars ~f:(fun v -> not (V.Assoc.mem vars v)) |> function
     | None -> ()
     | Some v -> invalid_argf "Undefined variable %a" V.pps v ()
 
@@ -220,7 +220,7 @@ type defn = Defn.t [@@deriving bin_io, compare, sexp]
 
 module Spec = struct
   type t = defn list
-    [@@deriving bin_io, compare, sexp]
+  [@@deriving bin_io, compare, sexp]
 
   let create defs =
     let compare x y = String.compare (Defn.name x) (Defn.name y) in

--- a/saluki/state.ml
+++ b/saluki/state.ml
@@ -92,7 +92,7 @@ let debug id term fmt =
 
 let sat ts term hypo kind v bil : hyp option =
   let dep_use hyp y x =
-    List.Assoc.find (Defn.vars hyp.defn) v >>|
+    V.Assoc.find (Defn.vars hyp.defn) v >>|
     taint_of_sort >>= fun taints ->
     match taints ts (Term.tid term) y with
     | ss -> match Map.find_exn hyp.deps (v,x) with
@@ -108,7 +108,7 @@ let sat ts term hypo kind v bil : hyp option =
             deps = Map.add hyp.deps ~key:(v,x) ~data:(Set ss)
           } in
   let dep_def hyp bil y =
-    List.Assoc.find (Defn.vars hyp.defn) v >>| seed_of_sort >>=
+    V.Assoc.find (Defn.vars hyp.defn) v >>| seed_of_sort >>=
     fun get_seed ->
     match get_seed ts (Term.tid term) bil, Map.find_exn hyp.deps (y,v) with
     | None,Top -> Some {

--- a/saluki/tests/test0.c
+++ b/saluki/tests/test0.c
@@ -6,7 +6,7 @@
 #include <stdio.h>
 
 int print_result(FILE *output, const char *msg) {
-    fprintf(output,msg);
+    fputs(msg,output);
 }
 
 int main() {

--- a/saluki/tests/test15.c
+++ b/saluki/tests/test15.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>

--- a/saluki/v.ml
+++ b/saluki/v.ml
@@ -23,6 +23,11 @@ end
 
 type t = int [@@deriving bin_io, compare, sexp]
 
+module Assoc = struct
+  let find = List.Assoc.find ~equal:Int.equal
+  let mem = List.Assoc.mem ~equal:Int.equal
+end
+
 let null = 0
 let create = Vars.register
 include Regular.Make(struct

--- a/saluki/v.mli
+++ b/saluki/v.mli
@@ -5,4 +5,8 @@ open Bap.Std
 type t = int
 val null   : t
 val create : string -> t
+module Assoc : sig
+  val find : (t * 'a) list -> t -> 'a option
+  val mem : (t * 'a) list -> t -> bool
+end
 include Regular.S with type t := t

--- a/test-expect/.merlin
+++ b/test-expect/.merlin
@@ -1,3 +1,4 @@
 REC
 PKG ocamlgraph
 PKG re
+B _build

--- a/test-expect/test.ml
+++ b/test-expect/test.ml
@@ -15,7 +15,7 @@ let subst = [
   "arch", "arm";
   "abi",  "linux-gnueabi";
   "cc", "gcc";
-  "ver", "4.7";
+  "ver", "5";
   "opt", "";
   "dir", test_folder;
   "options", "";
@@ -47,10 +47,16 @@ let expand pat map =
     pat;
   Buffer.contents buf
 
-let pipe cmd =
-  let inp = Unix.open_process_in cmd in
-  let r = In_channel.input_lines inp in
-  In_channel.close inp; r
+let pipe cmd : string list =
+  let env = Unix.environment () in
+  let out,inp,err = Unix.open_process_full cmd env in
+  Out_channel.close inp;
+  let res = List.concat [
+      In_channel.input_lines out;
+      In_channel.input_lines err;
+    ] in
+  List.iter ~f:In_channel.close [out;err];
+  res
 
 let sh cmd =
   if Sys.command cmd <> 0 then

--- a/test-expect/test.ml
+++ b/test-expect/test.ml
@@ -27,6 +27,8 @@ let verbose () = try Sys.getenv "VERBOSE" with Not_found -> "0"
 
 exception Command_failed of string [@@deriving sexp]
 
+let assoc = List.Assoc.find_exn ~equal:String.equal
+
 
 let result_of_string line =
   try Scanf.sscanf line "//! %s@\n" Option.some with exn -> None
@@ -40,7 +42,7 @@ let expand pat map =
   let buf = Buffer.create 64 in
   Buffer.add_substitute buf (fun key ->
       try Sys.getenv ("TEST_"^String.uppercase key) with
-        Not_found -> try List.Assoc.find_exn map key with
+        Not_found -> try assoc map key with
           Not_found -> failwithf "no subst for %s" key ())
     pat;
   Buffer.contents buf


### PR DESCRIPTION
Update Summary
=============

This update doesn't change anything in Saluki implementation and doesn't update it to the new Primus Framework. In this PR we are addressing breaking changes in OCaml infrastructure. Since, the BAP interface is stable, most of the changes are due to the breaking changes in the newest releases of Core (they are all about the `equal` parameter of different `mem` and `find` functions that became mandatory). BAP related changes all lies in the Makefile and are due to changed command line parameters and their semantics. 

Saluki State
=========

The Saluki is a finished project and we do not expect moving it any further. Saluki was tested and runs as expected on the following architectures:

* i686-linux-gnu
* i686-w64-mingw32
* x86_64-linux-gnu
* x86_64-w64-mingw32
* arm-linux-gnueabi
* powerpc-linux-gnu

Saluki currently doesn't work with `mips-linux-gnu` and `mips64-linux-gnu` as those targets are using indirect branches to call external function, and Saluki relies on a static control flow graph. This is a limitation of Saluki. The new Primus Test framework, that supersedes Saluki, doesn't have this limitation, neither does the underlying Microexecution technology.

Saluki also fails with `powerpc64-linux-gnu` target because BAP lacks a proper demangler. This is a limitation of BAP that will be addressed in the nearest future.

The test suite consists of 18 toy C programs.  Only ARM and PowerPC pass all tests with no false positives of false negatives. For x86 family there are 3 nearly identical false negatives (i.e., a property is unproved, although there exists a path that models the property) that are limitations of the Microflux technology (i.e., not all paths are checked in Microflux). 


