### PR TITLE
adds options to Saluki Makefile to enable Primus

### DIFF
--- a/saluki/Makefile
+++ b/saluki/Makefile
@@ -1,4 +1,14 @@
+ifeq (is_${TAINT_ENGINE}, is_primus)
+OPTS = ${options} \
+	--no-byteweight --saluki-print-models --propagate-taint-print-coverage \
+	--passes=trivial-condition-form,saluki-taint,run,saluki-solve \
+	--primus-propagate-taint-from-attr --primus-propagate-taint-to-attr \
+	--primus-promiscuous-mode --primus-greedy-scheduler \
+	--primus-limit-max-visited=64 --primus-limit-max-length=4096
+else
 OPTS = ${options} --no-byteweight --saluki --saluki-print-models --propagate-taint-print-coverage
+endif
+
 case = *
 TEST = tests/test${case}.c
 
@@ -15,10 +25,10 @@ test-expect:
 		make -C ../test-expect
 
 test : all test-expect
-		@TEST_OPTIONS="${OPTS}" bap-test-expect $(TEST)
+		TEST_OPTIONS="${OPTS}" bap-test-expect $(TEST)
 
 
-bap: saluki
+bap: all
 		bap ${binary} ${OPTS}
 
 clean:


### PR DESCRIPTION
With the following options we are able to pass all tests, provided
that the coverage requirement is levereged (since Primus doesn't
output coverage reports in the same way as the old framework did).

Usage:
```
make test TAINT_ENGINE=primus
```
Or (to test on an arbitrary binary `exe`)
```
make bap binary=exe TAINT_ENGINE=primus
```